### PR TITLE
Implement tray watchdog with configurable monitoring

### DIFF
--- a/ApplicationArguments.cs
+++ b/ApplicationArguments.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace ServiceWatchdogArr
+{
+    internal static class ApplicationArguments
+    {
+        public static bool SafeMode { get; private set; }
+
+        public static void Initialize(string[] args)
+        {
+            SafeMode = false;
+
+            foreach (string argument in args)
+            {
+                if (string.Equals(argument, "--safe-mode", StringComparison.OrdinalIgnoreCase))
+                {
+                    SafeMode = true;
+                }
+            }
+        }
+    }
+}

--- a/ApplicationEditorForm.cs
+++ b/ApplicationEditorForm.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.ServiceProcess;
+using System.Windows.Forms;
+
+namespace ServiceWatchdogArr
+{
+    internal sealed class ApplicationEditorForm : Form
+    {
+        private readonly TextBox _txtName = new TextBox();
+        private readonly TextBox _txtService = new TextBox();
+        private readonly TextBox _txtExecutable = new TextBox();
+        private readonly TextBox _txtProcessInput = new TextBox();
+        private readonly ListBox _lstProcesses = new ListBox();
+        private readonly CheckBox _chkMonitoring = new CheckBox();
+        private readonly ListView _lvServices = new ListView();
+        private readonly ListView _lvProcesses = new ListView();
+        private readonly Button _btnAddProcess = new Button();
+        private readonly Button _btnRemoveProcess = new Button();
+        private readonly Button _btnBrowseExecutable = new Button();
+        private readonly Button _btnRefresh = new Button();
+        private readonly Button _btnSave = new Button();
+        private readonly Button _btnCancel = new Button();
+
+        public ApplicationEditorForm()
+        {
+            InitializeComponent();
+            LoadLists();
+        }
+
+        public ApplicationEditorForm(MonitoredApplication application)
+            : this()
+        {
+            if (application != null)
+            {
+                _txtName.Text = application.Name;
+                _txtService.Text = application.ServiceName;
+                _txtExecutable.Text = application.ExecutablePath;
+                _chkMonitoring.Checked = application.MonitoringEnabled;
+                foreach (string process in application.ProcessNames)
+                {
+                    _lstProcesses.Items.Add(process);
+                }
+            }
+        }
+
+        public MonitoredApplication GetApplication()
+        {
+            var application = new MonitoredApplication
+            {
+                Name = _txtName.Text.Trim(),
+                ServiceName = _txtService.Text.Trim(),
+                ExecutablePath = _txtExecutable.Text.Trim(),
+                MonitoringEnabled = _chkMonitoring.Checked,
+                ProcessNames = _lstProcesses.Items.Cast<string>().Select(ProcessNameHelper.Normalize).Where(name => !string.IsNullOrWhiteSpace(name)).Distinct(StringComparer.OrdinalIgnoreCase).ToList()
+            };
+            application.Normalize();
+            return application;
+        }
+
+        private void InitializeComponent()
+        {
+            Text = "Application";
+            StartPosition = FormStartPosition.CenterParent;
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MinimizeBox = false;
+            MaximizeBox = false;
+            Width = 800;
+            Height = 520;
+
+            var rootLayout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 2
+            };
+            rootLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            rootLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            Controls.Add(rootLayout);
+
+            var detailsLayout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 2,
+                Padding = new Padding(10)
+            };
+            detailsLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 35F));
+            detailsLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 65F));
+            detailsLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            detailsLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            detailsLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            detailsLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            detailsLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            detailsLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+
+            var lblName = new Label { Text = "Friendly name:", AutoSize = true, Padding = new Padding(0, 6, 0, 0) };
+            var lblService = new Label { Text = "Service name:", AutoSize = true, Padding = new Padding(0, 6, 0, 0) };
+            var lblExecutable = new Label { Text = "Executable path:", AutoSize = true, Padding = new Padding(0, 6, 0, 0) };
+            var lblProcesses = new Label { Text = "Process names:", AutoSize = true, Padding = new Padding(0, 6, 0, 0) };
+
+            _chkMonitoring.Text = "Enable monitoring";
+            _chkMonitoring.Checked = true;
+
+            _btnBrowseExecutable.Text = "Browse…";
+            _btnBrowseExecutable.AutoSize = true;
+            _btnBrowseExecutable.Click += (_, _) => BrowseExecutable();
+
+            var executablePanel = new TableLayoutPanel { ColumnCount = 2, Dock = DockStyle.Fill };
+            executablePanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            executablePanel.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            executablePanel.Controls.Add(_txtExecutable, 0, 0);
+            executablePanel.Controls.Add(_btnBrowseExecutable, 1, 0);
+
+            _lstProcesses.SelectionMode = SelectionMode.MultiExtended;
+            _lstProcesses.Height = 120;
+
+            _btnAddProcess.Text = "Add";
+            _btnAddProcess.AutoSize = true;
+            _btnAddProcess.Click += (_, _) => AddProcessFromText();
+
+            _btnRemoveProcess.Text = "Remove";
+            _btnRemoveProcess.AutoSize = true;
+            _btnRemoveProcess.Click += (_, _) => RemoveSelectedProcesses();
+
+            var processInputPanel = new FlowLayoutPanel
+            {
+                FlowDirection = FlowDirection.LeftToRight,
+                Dock = DockStyle.Fill,
+                AutoSize = true
+            };
+            _txtProcessInput.Width = 200;
+            processInputPanel.Controls.Add(_txtProcessInput);
+            processInputPanel.Controls.Add(_btnAddProcess);
+            processInputPanel.Controls.Add(_btnRemoveProcess);
+
+            detailsLayout.Controls.Add(lblName, 0, 0);
+            detailsLayout.Controls.Add(_txtName, 1, 0);
+            detailsLayout.Controls.Add(lblService, 0, 1);
+            detailsLayout.Controls.Add(_txtService, 1, 1);
+            detailsLayout.Controls.Add(lblExecutable, 0, 2);
+            detailsLayout.Controls.Add(executablePanel, 1, 2);
+            detailsLayout.Controls.Add(lblProcesses, 0, 3);
+            detailsLayout.Controls.Add(_lstProcesses, 1, 3);
+            detailsLayout.Controls.Add(processInputPanel, 1, 4);
+            detailsLayout.Controls.Add(_chkMonitoring, 1, 5);
+
+            rootLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            rootLayout.Controls.Add(detailsLayout, 0, 0);
+
+            var discoveryLayout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 1,
+                Padding = new Padding(10)
+            };
+            discoveryLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            discoveryLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            discoveryLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+
+            _lvServices.View = View.Details;
+            _lvServices.FullRowSelect = true;
+            _lvServices.MultiSelect = false;
+            _lvServices.HideSelection = false;
+            _lvServices.Columns.Add("Service", 180);
+            _lvServices.Columns.Add("Name", 160);
+            _lvServices.Dock = DockStyle.Fill;
+            _lvServices.DoubleClick += (_, _) => ApplySelectedService();
+
+            _lvProcesses.View = View.Details;
+            _lvProcesses.FullRowSelect = true;
+            _lvProcesses.MultiSelect = false;
+            _lvProcesses.HideSelection = false;
+            _lvProcesses.Columns.Add("Process", 180);
+            _lvProcesses.Columns.Add("PID", 80);
+            _lvProcesses.Dock = DockStyle.Fill;
+            _lvProcesses.DoubleClick += (_, _) => AddSelectedProcess();
+
+            _btnRefresh.Text = "Refresh";
+            _btnRefresh.AutoSize = true;
+            _btnRefresh.Click += (_, _) => LoadLists();
+
+            discoveryLayout.Controls.Add(_lvServices, 0, 0);
+            discoveryLayout.Controls.Add(_lvProcesses, 0, 1);
+            discoveryLayout.Controls.Add(_btnRefresh, 0, 2);
+
+            rootLayout.Controls.Add(discoveryLayout, 1, 0);
+
+            var actionsPanel = new FlowLayoutPanel
+            {
+                Dock = DockStyle.Bottom,
+                FlowDirection = FlowDirection.RightToLeft,
+                Padding = new Padding(10),
+                AutoSize = true
+            };
+
+            _btnSave.Text = "OK";
+            _btnSave.AutoSize = true;
+            _btnSave.Click += (_, _) => OnSave();
+
+            _btnCancel.Text = "Cancel";
+            _btnCancel.AutoSize = true;
+            _btnCancel.DialogResult = DialogResult.Cancel;
+
+            actionsPanel.Controls.Add(_btnSave);
+            actionsPanel.Controls.Add(_btnCancel);
+            Controls.Add(actionsPanel);
+
+            AcceptButton = _btnSave;
+            CancelButton = _btnCancel;
+        }
+
+        private void BrowseExecutable()
+        {
+            using var dialog = new OpenFileDialog
+            {
+                Filter = "Executable Files (*.exe)|*.exe|All Files (*.*)|*.*",
+                Title = "Select executable"
+            };
+
+            if (dialog.ShowDialog(this) == DialogResult.OK)
+            {
+                _txtExecutable.Text = dialog.FileName;
+            }
+        }
+
+        private void AddProcessFromText()
+        {
+            string process = ProcessNameHelper.Normalize(_txtProcessInput.Text);
+            if (string.IsNullOrWhiteSpace(process))
+            {
+                return;
+            }
+
+            if (!_lstProcesses.Items.Contains(process))
+            {
+                _lstProcesses.Items.Add(process);
+            }
+
+            _txtProcessInput.Clear();
+        }
+
+        private void RemoveSelectedProcesses()
+        {
+            var items = _lstProcesses.SelectedItems.Cast<object>().ToList();
+            foreach (var item in items)
+            {
+                _lstProcesses.Items.Remove(item);
+            }
+        }
+
+        private void ApplySelectedService()
+        {
+            if (_lvServices.SelectedItems.Count != 1)
+            {
+                return;
+            }
+
+            var item = _lvServices.SelectedItems[0];
+            string serviceName = item.SubItems[1].Text;
+            string displayName = item.SubItems[0].Text;
+            _txtService.Text = serviceName;
+            if (string.IsNullOrWhiteSpace(_txtName.Text))
+            {
+                _txtName.Text = displayName;
+            }
+        }
+
+        private void AddSelectedProcess()
+        {
+            if (_lvProcesses.SelectedItems.Count != 1)
+            {
+                return;
+            }
+
+            string processName = _lvProcesses.SelectedItems[0].SubItems[0].Text;
+            string normalized = ProcessNameHelper.Normalize(processName);
+            if (!_lstProcesses.Items.Contains(normalized))
+            {
+                _lstProcesses.Items.Add(normalized);
+            }
+        }
+
+        private void LoadLists()
+        {
+            LoadServices();
+            LoadProcesses();
+        }
+
+        private void LoadServices()
+        {
+            _lvServices.BeginUpdate();
+            _lvServices.Items.Clear();
+            try
+            {
+                foreach (ServiceController service in ServiceController.GetServices())
+                {
+                    var item = new ListViewItem(service.DisplayName);
+                    item.SubItems.Add(service.ServiceName);
+                    _lvServices.Items.Add(item);
+                }
+            }
+            catch
+            {
+                // Ignore enumeration errors.
+            }
+            finally
+            {
+                _lvServices.EndUpdate();
+            }
+        }
+
+        private void LoadProcesses()
+        {
+            _lvProcesses.BeginUpdate();
+            _lvProcesses.Items.Clear();
+            try
+            {
+                foreach (Process process in Process.GetProcesses())
+                {
+                    try
+                    {
+                        var item = new ListViewItem(process.ProcessName);
+                        item.SubItems.Add(process.Id.ToString());
+                        _lvProcesses.Items.Add(item);
+                    }
+                    finally
+                    {
+                        process.Dispose();
+                    }
+                }
+            }
+            catch
+            {
+                // Ignore enumeration errors.
+            }
+            finally
+            {
+                _lvProcesses.EndUpdate();
+            }
+        }
+
+        private void OnSave()
+        {
+            if (string.IsNullOrWhiteSpace(_txtName.Text))
+            {
+                MessageBox.Show(this, "A friendly name is required.", "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(_txtService.Text) && _lstProcesses.Items.Count == 0)
+            {
+                var confirm = MessageBox.Show(this, "No service or process names are specified. Continue?", "Confirm", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                if (confirm != DialogResult.Yes)
+                {
+                    return;
+                }
+            }
+
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+    }
+}

--- a/AutoStartHelper.cs
+++ b/AutoStartHelper.cs
@@ -9,7 +9,7 @@ namespace ServiceWatchdogArr
 
         public static void Enable(string exePath)
         {
-            using var key = Registry.CurrentUser.OpenSubKey(RUN_KEY, writable: true);
+            using var key = Registry.CurrentUser.CreateSubKey(RUN_KEY, writable: true);
             key?.SetValue(APP_NAME, $"\"{exePath}\"");
         }
 

--- a/CrashReporter.cs
+++ b/CrashReporter.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace ServiceWatchdogArr
+{
+    internal static class CrashReporter
+    {
+        private static int _initialized;
+
+        public static void Initialize()
+        {
+            if (Interlocked.Exchange(ref _initialized, 1) == 1)
+            {
+                return;
+            }
+
+            Application.ThreadException += OnThreadException;
+            AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+        }
+
+        public static void CheckForRecentCrash()
+        {
+            try
+            {
+                if (!File.Exists(Paths.LastCrashMarkerPath))
+                {
+                    return;
+                }
+
+                string content = File.ReadAllText(Paths.LastCrashMarkerPath);
+                if (DateTime.TryParseExact(content, "O", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime crashUtc))
+                {
+                    if (DateTime.UtcNow - crashUtc <= TimeSpan.FromMinutes(5))
+                    {
+                        Logger.Write("Previous crash detected within the last five minutes.");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Write(ex, "Failed to evaluate crash marker");
+            }
+        }
+
+        private static void OnThreadException(object sender, ThreadExceptionEventArgs e)
+        {
+            HandleException(e.Exception, "UI thread exception");
+        }
+
+        private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            if (e.ExceptionObject is Exception exception)
+            {
+                HandleException(exception, "Unhandled exception");
+            }
+        }
+
+        private static void HandleException(Exception exception, string context)
+        {
+            try
+            {
+                Logger.Write(exception, context);
+                WriteCrashFile(exception, context);
+            }
+            catch
+            {
+                // Ignore nested failures.
+            }
+        }
+
+        private static void WriteCrashFile(Exception exception, string context)
+        {
+            try
+            {
+                Directory.CreateDirectory(Paths.AppDataDirectory);
+                string timestamp = DateTime.Now.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
+                string crashFile = string.Concat(Paths.CrashLogFilePrefix, timestamp, ".log");
+                var builder = new StringBuilder();
+                builder.AppendLine(context);
+                builder.AppendLine(DateTime.Now.ToString("O", CultureInfo.InvariantCulture));
+                builder.AppendLine(exception.ToString());
+                File.WriteAllText(crashFile, builder.ToString());
+                File.WriteAllText(Paths.LastCrashMarkerPath, DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture));
+            }
+            catch
+            {
+                // Ignore crash file failures.
+            }
+        }
+    }
+}

--- a/Logger.cs
+++ b/Logger.cs
@@ -1,54 +1,163 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 using System.IO;
+using System.Linq;
+using System.Text;
 
 namespace ServiceWatchdogArr
 {
-    public static class Logger
+    internal static class Logger
     {
-        private static readonly string LogDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "ServiceWatchdogArr");
-
-        private static readonly string LogFile = Path.Combine(LogDir, "watchdog.log");
+        private const long MaxLogSizeBytes = 5L * 1024L * 1024L;
+        private static readonly object SyncRoot = new object();
 
         static Logger()
         {
-            if (!Directory.Exists(LogDir))
-                Directory.CreateDirectory(LogDir);
+            Directory.CreateDirectory(Paths.AppDataDirectory);
         }
 
         public static void Write(string message)
         {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return;
+            }
+
             try
             {
-                string line = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {message}";
-
-                const long maxSizeBytes = 5 * 1024 * 1024;
-                var fi = new FileInfo(LogFile);
-
-                if (fi.Exists && fi.Length > maxSizeBytes)
+                lock (SyncRoot)
                 {
-                    string archive = Path.Combine(LogDir, $"watchdog_{DateTime.Now:yyyyMMddHHmmss}.log");
-                    File.Move(LogFile, archive, true);
+                    RotateIfNeeded();
+                    var line = FormatLine(message);
+                    File.AppendAllText(Paths.LogFilePath, line, Encoding.UTF8);
+                }
+            }
+            catch
+            {
+                // Intentionally swallow logging failures. Avoid throwing from logger.
+            }
+        }
 
-                    foreach (var f in Directory.GetFiles(LogDir, "watchdog_*.log"))
+        public static void Write(Exception exception, string context)
+        {
+            if (exception == null)
+            {
+                return;
+            }
+
+            var builder = new StringBuilder();
+            builder.Append(context);
+            builder.AppendLine();
+            builder.AppendLine(exception.ToString());
+            Write(builder.ToString());
+        }
+
+        public static void EnsureLogExists()
+        {
+            try
+            {
+                if (!File.Exists(Paths.LogFilePath))
+                {
+                    lock (SyncRoot)
                     {
-                        if (File.GetCreationTime(f) < DateTime.Now.AddDays(-7))
-                            File.Delete(f);
+                        if (!File.Exists(Paths.LogFilePath))
+                        {
+                            File.AppendAllText(Paths.LogFilePath, FormatLine("Log created."), Encoding.UTF8);
+                        }
                     }
                 }
-
-                File.AppendAllLines(LogFile, new[] { line });
             }
-            catch { }
+            catch
+            {
+                // Ignore creation errors.
+            }
         }
 
         public static void OpenLog()
         {
-            if (File.Exists(LogFile))
-                System.Diagnostics.Process.Start("notepad.exe", LogFile);
-            else
-                Write("Log file created.");
+            try
+            {
+                EnsureLogExists();
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = Paths.LogFilePath,
+                    UseShellExecute = true
+                };
+                Process.Start(startInfo);
+            }
+            catch (Exception ex)
+            {
+                Write(ex, "Failed to open log file");
+            }
+        }
+
+        private static void RotateIfNeeded()
+        {
+            try
+            {
+                if (!File.Exists(Paths.LogFilePath))
+                {
+                    return;
+                }
+
+                var fileInfo = new FileInfo(Paths.LogFilePath);
+                if (fileInfo.Length <= MaxLogSizeBytes)
+                {
+                    return;
+                }
+
+                string archiveName = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "watchdog_{0:yyyyMMddHHmmss}.log",
+                    DateTime.Now);
+                string archivePath = Path.Combine(Paths.AppDataDirectory, archiveName);
+                File.Move(Paths.LogFilePath, archivePath, overwrite: true);
+
+                PurgeOldArchives();
+            }
+            catch
+            {
+                // Ignore rotation errors. We prefer stale logs over failed writes.
+            }
+        }
+
+        private static void PurgeOldArchives()
+        {
+            try
+            {
+                var cutoff = DateTime.Now.AddDays(-7);
+                IEnumerable<string> archives = Directory.EnumerateFiles(Paths.AppDataDirectory, "watchdog_*.log");
+                foreach (string archive in archives)
+                {
+                    try
+                    {
+                        if (File.GetCreationTime(archive) < cutoff)
+                        {
+                            File.Delete(archive);
+                        }
+                    }
+                    catch
+                    {
+                        // Ignore deletion errors.
+                    }
+                }
+            }
+            catch
+            {
+                // Ignore purge errors.
+            }
+        }
+
+        private static string FormatLine(string message)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "[{0:yyyy-MM-dd HH:mm:ss}] {1}{2}",
+                DateTime.Now,
+                message.TrimEnd('\r', '\n'),
+                Environment.NewLine);
         }
     }
 }

--- a/MonitoringEngine.cs
+++ b/MonitoringEngine.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ServiceWatchdogArr
+{
+    internal sealed class MonitoringEngine : IDisposable
+    {
+        private readonly ServiceManager _serviceManager = new ServiceManager();
+        private readonly ProcessManager _processManager = new ProcessManager();
+        private readonly object _syncRoot = new object();
+        private readonly SemaphoreSlim _cycleLock = new SemaphoreSlim(1, 1);
+        private Timer _timer;
+        private WatchdogConfig _config;
+        private List<ApplicationStatusSnapshot> _latest = new List<ApplicationStatusSnapshot>();
+        private bool _disposed;
+
+        public MonitoringEngine(WatchdogConfig config)
+        {
+            _config = config.Clone();
+            _timer = new Timer(OnTimerTick, null, TimeSpan.Zero, _config.MonitoringInterval);
+        }
+
+        public event EventHandler<MonitoringCycleEventArgs> MonitoringCycleCompleted;
+
+        public IReadOnlyList<ApplicationStatusSnapshot> LatestSnapshot
+        {
+            get
+            {
+                lock (_syncRoot)
+                {
+                    return _latest.Select(static status => status.Clone()).ToList();
+                }
+            }
+        }
+
+        public void ApplyConfiguration(WatchdogConfig config)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            lock (_syncRoot)
+            {
+                _config = config.Clone();
+                _timer?.Change(TimeSpan.Zero, _config.MonitoringInterval);
+            }
+        }
+
+        public Task RefreshNowAsync()
+        {
+            return RunCycleAsync();
+        }
+
+        private void OnTimerTick(object state)
+        {
+            _ = RunCycleAsync();
+        }
+
+        private async Task RunCycleAsync()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (!await _cycleLock.WaitAsync(0).ConfigureAwait(false))
+            {
+                return;
+            }
+
+            try
+            {
+                WatchdogConfig configSnapshot;
+                lock (_syncRoot)
+                {
+                    configSnapshot = _config.Clone();
+                }
+
+                var statuses = new List<ApplicationStatusSnapshot>();
+                foreach (MonitoredApplication application in configSnapshot.Applications)
+                {
+                    ServiceQueryResult serviceStatus = _serviceManager.QueryStatus(application.ServiceName);
+                    ProcessQueryResult processStatus = _processManager.QueryProcesses(application.ProcessNames);
+                    var snapshot = new ApplicationStatusSnapshot(application, configSnapshot.GlobalMonitoringEnabled, serviceStatus, processStatus);
+                    statuses.Add(snapshot);
+                    LogStatus(snapshot);
+                }
+
+                lock (_syncRoot)
+                {
+                    _latest = statuses.Select(static status => status.Clone()).ToList();
+                }
+
+                MonitoringCycleCompleted?.Invoke(this, new MonitoringCycleEventArgs(DateTime.Now, statuses));
+            }
+            catch (Exception ex)
+            {
+                Logger.Write(ex, "Monitoring cycle failure");
+            }
+            finally
+            {
+                _cycleLock.Release();
+            }
+        }
+
+        private static void LogStatus(ApplicationStatusSnapshot snapshot)
+        {
+            string servicePart;
+            if (!snapshot.Service.Exists)
+            {
+                servicePart = "service not configured";
+            }
+            else if (snapshot.Service.AccessDenied)
+            {
+                servicePart = "service access denied";
+            }
+            else if (snapshot.Service.HasError)
+            {
+                servicePart = $"service error: {snapshot.Service.Error}";
+            }
+            else
+            {
+                servicePart = snapshot.ServiceRunning ? "service running" : "service stopped";
+            }
+
+            string processPart;
+            if (snapshot.ProcessNames.Count == 0)
+            {
+                processPart = "process not configured";
+            }
+            else if (snapshot.ProcessRunning)
+            {
+                processPart = $"process running ({string.Join(", ", snapshot.Process.RunningProcesses)})";
+            }
+            else
+            {
+                processPart = "process stopped";
+            }
+
+            string monitoringInfo = snapshot.EffectiveMonitoringEnabled ? "monitoring active" : "monitoring disabled";
+            Logger.Write($"[{snapshot.Application.Name}] {servicePart}; {processPart}; {monitoringInfo}");
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _timer?.Dispose();
+            _cycleLock.Dispose();
+        }
+    }
+
+    internal sealed class MonitoringCycleEventArgs : EventArgs
+    {
+        public MonitoringCycleEventArgs(DateTime timestamp, IReadOnlyList<ApplicationStatusSnapshot> statuses)
+        {
+            Timestamp = timestamp;
+            Statuses = statuses;
+        }
+
+        public DateTime Timestamp { get; }
+
+        public IReadOnlyList<ApplicationStatusSnapshot> Statuses { get; }
+    }
+
+    internal enum ApplicationHealth
+    {
+        MonitoringDisabled,
+        Healthy,
+        Unhealthy
+    }
+
+    internal sealed class ApplicationStatusSnapshot
+    {
+        public ApplicationStatusSnapshot(MonitoredApplication application, bool globalMonitoringEnabled, ServiceQueryResult service, ProcessQueryResult process)
+        {
+            Application = application.Clone();
+            GlobalMonitoringEnabled = globalMonitoringEnabled;
+            Service = service;
+            Process = process;
+        }
+
+        public MonitoredApplication Application { get; }
+
+        public bool GlobalMonitoringEnabled { get; }
+
+        public ServiceQueryResult Service { get; }
+
+        public ProcessQueryResult Process { get; }
+
+        public bool ServiceRunning => Service.IsRunning;
+
+        public bool ProcessRunning => Process.AnyRunning;
+
+        public bool EffectiveMonitoringEnabled => GlobalMonitoringEnabled && Application.MonitoringEnabled;
+
+        public ApplicationHealth Health
+        {
+            get
+            {
+                if (!EffectiveMonitoringEnabled)
+                {
+                    return ApplicationHealth.MonitoringDisabled;
+                }
+
+                return ServiceRunning || ProcessRunning ? ApplicationHealth.Healthy : ApplicationHealth.Unhealthy;
+            }
+        }
+
+        public IReadOnlyList<string> ProcessNames => Application.ProcessNames;
+
+        public ApplicationStatusSnapshot Clone()
+        {
+            return new ApplicationStatusSnapshot(Application, GlobalMonitoringEnabled, Service, Process);
+        }
+    }
+}

--- a/Paths.cs
+++ b/Paths.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+
+namespace ServiceWatchdogArr
+{
+    internal static class Paths
+    {
+        static Paths()
+        {
+            Directory.CreateDirectory(AppDataDirectory);
+        }
+
+        public static string AppDataDirectory { get; } = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "ServiceWatchdogArr");
+
+        public static string ConfigFilePath => Path.Combine(AppDataDirectory, "appsettings.json");
+
+        public static string LogFilePath => Path.Combine(AppDataDirectory, "watchdog.log");
+
+        public static string CrashLogFilePrefix => Path.Combine(AppDataDirectory, "crash-");
+
+        public static string LastCrashMarkerPath => Path.Combine(AppDataDirectory, "last-crash.txt");
+    }
+}

--- a/ProcessManager.cs
+++ b/ProcessManager.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace ServiceWatchdogArr
+{
+    internal sealed class ProcessManager
+    {
+        private const int KillWaitMilliseconds = 10000;
+
+        public ProcessQueryResult QueryProcesses(IEnumerable<string> processNames)
+        {
+            List<string> targets = NormalizeTargets(processNames);
+            if (targets.Count == 0)
+            {
+                return ProcessQueryResult.Empty;
+            }
+
+            var running = new List<string>();
+            Process[] processes;
+            try
+            {
+                processes = Process.GetProcesses();
+            }
+            catch
+            {
+                return ProcessQueryResult.Empty;
+            }
+
+            foreach (Process process in processes)
+            {
+                try
+                {
+                    string normalized = ProcessNameHelper.Normalize(process.ProcessName);
+                    if (targets.Contains(normalized, StringComparer.OrdinalIgnoreCase))
+                    {
+                        running.Add(process.ProcessName);
+                    }
+                }
+                catch
+                {
+                    // Ignore observation errors.
+                }
+                finally
+                {
+                    process.Dispose();
+                }
+            }
+
+            return new ProcessQueryResult(running);
+        }
+
+        public bool KillProcesses(IEnumerable<string> processNames, string applicationName)
+        {
+            List<string> targets = NormalizeTargets(processNames);
+            if (targets.Count == 0)
+            {
+                return false;
+            }
+
+            bool terminatedAny = false;
+            Process[] processes;
+            try
+            {
+                processes = Process.GetProcesses();
+            }
+            catch (Exception ex)
+            {
+                Logger.Write(ex, $"Failed to enumerate processes for {applicationName}");
+                return false;
+            }
+
+            foreach (Process process in processes)
+            {
+                try
+                {
+                    string normalized = ProcessNameHelper.Normalize(process.ProcessName);
+                    if (!targets.Contains(normalized, StringComparer.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    Logger.Write($"Terminating process {process.ProcessName} (PID {process.Id}) for {applicationName}");
+                    process.Kill(true);
+                    terminatedAny = true;
+                    process.WaitForExit(KillWaitMilliseconds);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Write(ex, $"Failed to terminate process {process.ProcessName} for {applicationName}");
+                }
+                finally
+                {
+                    process.Dispose();
+                }
+            }
+
+            return terminatedAny;
+        }
+
+        public bool StartProcess(string executablePath, string applicationName)
+        {
+            if (string.IsNullOrWhiteSpace(executablePath) || !File.Exists(executablePath))
+            {
+                return false;
+            }
+
+            try
+            {
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = executablePath,
+                    UseShellExecute = true
+                };
+                Process.Start(startInfo);
+                Logger.Write($"Launched executable for {applicationName}: {executablePath}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Write(ex, $"Failed to start executable for {applicationName}");
+                return false;
+            }
+        }
+
+        private static List<string> NormalizeTargets(IEnumerable<string> processNames)
+        {
+            return processNames
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Select(static name => ProcessNameHelper.Normalize(name))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+    }
+
+    internal readonly struct ProcessQueryResult
+    {
+        public static ProcessQueryResult Empty => new ProcessQueryResult(Array.Empty<string>());
+
+        public ProcessQueryResult(IEnumerable<string> runningProcesses)
+        {
+            RunningProcesses = runningProcesses.ToArray();
+        }
+
+        public IReadOnlyList<string> RunningProcesses { get; }
+
+        public bool AnyRunning => RunningProcesses.Count > 0;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,21 +1,87 @@
 # ServiceWatchdogArr
 
-Windows tray watchdog for Plex, Radarr, Sonarr, Docker Desktop, iCUE.
+ServiceWatchdogArr is a Windows 10/11 tray application that keeps user-selected services and/or processes running. It monitors the configured applications on a schedule, restarts them when required, and exposes configuration and diagnostic tooling directly from the tray icon.
 
-- Tray status: green, red, gray.
-- Right-click menu: status, enable/disable monitoring, settings, per-app restart, exit.
-- Settings: interval minutes/hours/days, run at startup, toggle monitoring.
-- Config is stored in `appsettings.json` with root object containing `WatchdogConfig`.
+## Key features
 
-## Build
-- Requires .NET 9 SDK on Windows.
-- Open `ServiceWatchdogArr.csproj` in Visual Studio, or run:
+- **Single instance** WinForms tray application targeting .NET 9. Launching a second instance focuses the existing session.
+- **Emoji status indicators** (🟢/🔴/⚪) in the tray menu showing per-application health.
+- **Configurable monitoring interval** (minutes, hours, or days) with global and per-application monitoring toggles.
+- **Restart workflow** that stops services, terminates matching processes, and relaunches executables. Safe mode disables restarts entirely.
+- **Session logging** with rolling logs (5 MB, seven-day retention) and crash reports written to `%AppData%\ServiceWatchdogArr`.
+- **Crash resilience:** unhandled exceptions are captured and persisted (`crash-*.log`). The next launch logs when a crash occurred within the last five minutes.
+- **Safe mode (`--safe-mode`)** for read-only monitoring (no service/process control) suitable for diagnostics.
+- **HKCU Run key integration** to optionally launch at Windows startup without elevation.
+
+## Configuration
+
+- Configuration is stored per-user at `%AppData%\ServiceWatchdogArr\appsettings.json`.
+- The schema matches the sample `appsettings.json` in the repository:
+  ```json
+  {
+    "WatchdogConfig": {
+      "Interval": { "Value": 5, "Unit": "Minutes" },
+      "AutoStart": false,
+      "GlobalMonitoringEnabled": true,
+      "Applications": [
+        {
+          "Name": "Docker Desktop",
+          "ServiceName": "com.docker.service",
+          "ProcessNames": ["Docker Desktop", "Docker Desktop Backend"],
+          "ExecutablePath": "C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe",
+          "MonitoringEnabled": true
+        }
+      ]
+    }
+  }
   ```
-  dotnet build -c Release
-  dotnet run
-  ```
+- The Settings window allows adding, editing, and removing applications. The add/edit dialog can discover currently running Windows services and processes, or you can enter details manually.
 
-## Notes
-- Icons are generated dynamically in memory so no external `.ico` files are required.
-- If an application has a `ServiceName`, the app uses ServiceController to start/stop.
-- If only a process path is present, the app launches the executable.
+## Usage
+
+1. Launch `ServiceWatchdogArr.exe`. The tray icon appears using `Resources/icon.ico` and immediately begins monitoring using the configured interval.
+2. Right-click the tray icon to access:
+   - **Services** submenu for each monitored application with `Restart` and `Enable/Disable Monitoring` actions.
+   - **Global Monitoring Enabled** toggle for pausing all monitoring.
+   - **Refresh Now** to force an immediate status check.
+   - **Open Logs** to view `%AppData%\ServiceWatchdogArr\watchdog.log` in the shell default handler.
+   - **Settings…** for interval/autostart configuration and application management.
+   - **Exit** to shut down the tray application.
+3. The tray tooltip reports the aggregate state (`All OK`, `Issue detected`, or `Monitoring off`). When safe mode is active the tooltip includes “Safe Mode”.
+4. Run with `--safe-mode` to disable service/process restarts, termination, and launching. Menu actions remain visible but restart is disabled.
+
+## Logging & diagnostics
+
+- Operational log: `%AppData%\ServiceWatchdogArr\watchdog.log` (rotated at 5 MB, archives retained for seven days).
+- Crash logs: `%AppData%\ServiceWatchdogArr\crash-*.log` plus `last-crash.txt` for the most recent crash timestamp.
+- Use the tray **Open Logs** command to jump directly to the log file.
+
+## Building
+
+1. Install the .NET 9 SDK (Windows).
+2. Restore and build:
+   ```powershell
+   dotnet build -c Release
+   ```
+3. Run locally:
+   ```powershell
+   dotnet run --project ServiceWatchdogArr.csproj
+   ```
+4. Create a single-file portable publish (recommended for distribution):
+   ```powershell
+   dotnet publish ServiceWatchdogArr.csproj -c Release -r win-x64 \
+       -p:PublishSingleFile=true -p:SelfContained=true \
+       -p:IncludeAllContentForSelfExtract=true -p:PublishTrimmed=false
+   ```
+   Package the publish output as a ZIP alongside the default `appsettings.json` template and resources.
+
+## WinGet manifest
+
+The repository includes a template at `packaging/winget/manifest.yaml`. Before publishing:
+
+1. Update `Version`, `InstallerUrl`, and `InstallerSha256` with the artifacts for the current release.
+2. Submit the manifest to the [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository following the WinGet contribution guidelines.
+
+## License
+
+ServiceWatchdogArr is released under the [MIT License](LICENSE).

--- a/ServiceManager.cs
+++ b/ServiceManager.cs
@@ -1,0 +1,139 @@
+using System;
+using System.ComponentModel;
+using System.ServiceProcess;
+
+namespace ServiceWatchdogArr
+{
+    internal sealed class ServiceManager
+    {
+        private static readonly TimeSpan StopTimeout = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan StartTimeout = TimeSpan.FromSeconds(30);
+
+        public ServiceQueryResult QueryStatus(string serviceName)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+            {
+                return ServiceQueryResult.NotConfigured;
+            }
+
+            try
+            {
+                using ServiceController controller = new ServiceController(serviceName);
+                controller.Refresh();
+                bool running = controller.Status == ServiceControllerStatus.Running ||
+                               controller.Status == ServiceControllerStatus.StartPending;
+                return new ServiceQueryResult(true, running, false, null);
+            }
+            catch (InvalidOperationException ex) when (IsAccessDenied(ex))
+            {
+                return new ServiceQueryResult(true, false, true, ex.Message);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return new ServiceQueryResult(false, false, false, ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return new ServiceQueryResult(true, false, false, ex.Message);
+            }
+        }
+
+        public ServiceRestartResult RestartService(string serviceName)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+            {
+                return ServiceRestartResult.Skipped;
+            }
+
+            try
+            {
+                using ServiceController controller = new ServiceController(serviceName);
+                controller.Refresh();
+
+                if (controller.Status == ServiceControllerStatus.StopPending)
+                {
+                    controller.WaitForStatus(ServiceControllerStatus.Stopped, StopTimeout);
+                }
+
+                if (controller.Status != ServiceControllerStatus.Stopped &&
+                    controller.Status != ServiceControllerStatus.StopPending)
+                {
+                    controller.Stop();
+                    controller.WaitForStatus(ServiceControllerStatus.Stopped, StopTimeout);
+                }
+
+                controller.Start();
+                controller.WaitForStatus(ServiceControllerStatus.Running, StartTimeout);
+                return ServiceRestartResult.Success;
+            }
+            catch (InvalidOperationException ex) when (IsAccessDenied(ex))
+            {
+                return ServiceRestartResult.RequiresElevation(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return ServiceRestartResult.Failure(ex.Message);
+            }
+        }
+
+        private static bool IsAccessDenied(Exception ex)
+        {
+            if (ex is InvalidOperationException invalidOperation && invalidOperation.InnerException is Win32Exception win32)
+            {
+                return win32.NativeErrorCode == 5;
+            }
+
+            return false;
+        }
+    }
+
+    internal readonly struct ServiceQueryResult
+    {
+        public static ServiceQueryResult NotConfigured => new ServiceQueryResult(false, false, false, null);
+
+        public ServiceQueryResult(bool exists, bool running, bool accessDenied, string error)
+        {
+            Exists = exists;
+            IsRunning = running;
+            AccessDenied = accessDenied;
+            Error = error;
+        }
+
+        public bool Exists { get; }
+
+        public bool IsRunning { get; }
+
+        public bool AccessDenied { get; }
+
+        public string Error { get; }
+
+        public bool HasError => !string.IsNullOrWhiteSpace(Error);
+    }
+
+    internal readonly struct ServiceRestartResult
+    {
+        private ServiceRestartResult(bool succeeded, bool requiresElevation, string message, bool skipped)
+        {
+            Succeeded = succeeded;
+            RequiresElevation = requiresElevation;
+            Message = message;
+            Skipped = skipped;
+        }
+
+        public bool Succeeded { get; }
+
+        public bool RequiresElevation { get; }
+
+        public string Message { get; }
+
+        public bool Skipped { get; }
+
+        public static ServiceRestartResult Success => new ServiceRestartResult(true, false, string.Empty, false);
+
+        public static ServiceRestartResult RequiresElevation(string message) => new ServiceRestartResult(false, true, message, false);
+
+        public static ServiceRestartResult Failure(string message) => new ServiceRestartResult(false, false, message, false);
+
+        public static ServiceRestartResult Skipped => new ServiceRestartResult(true, false, string.Empty, true);
+    }
+}

--- a/ServiceWatchdogArr.csproj
+++ b/ServiceWatchdogArr.csproj
@@ -4,9 +4,11 @@
     <TargetFramework>net9.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>Resources\icon.ico</ApplicationIcon>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.0" />

--- a/SettingsForm.Designer.cs
+++ b/SettingsForm.Designer.cs
@@ -1,70 +1,249 @@
-using System.Windows.Forms;
-
 namespace ServiceWatchdogArr
 {
     partial class SettingsForm
     {
-        private System.ComponentModel.IContainer components = null!;
-        private NumericUpDown numInterval = null!;
-        private ComboBox cmbUnit = null!;
-        private CheckBox chkAutoStart = null!;
-        private Button btnSave = null!;
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.TabControl tabControl;
+        private System.Windows.Forms.TabPage tabGeneral;
+        private System.Windows.Forms.TabPage tabApplications;
+        private System.Windows.Forms.NumericUpDown numInterval;
+        private System.Windows.Forms.ComboBox cmbUnit;
+        private System.Windows.Forms.CheckBox chkAutoStart;
+        private System.Windows.Forms.CheckBox chkGlobalMonitoring;
+        private System.Windows.Forms.ListView lvApplications;
+        private System.Windows.Forms.ColumnHeader colName;
+        private System.Windows.Forms.ColumnHeader colService;
+        private System.Windows.Forms.ColumnHeader colProcesses;
+        private System.Windows.Forms.ColumnHeader colExecutable;
+        private System.Windows.Forms.ColumnHeader colMonitoring;
+        private System.Windows.Forms.Button btnAddApplication;
+        private System.Windows.Forms.Button btnEditApplication;
+        private System.Windows.Forms.Button btnRemoveApplication;
+        private System.Windows.Forms.Button btnSave;
+        private System.Windows.Forms.Button btnCancel;
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null)) components.Dispose();
+            if (disposing && components != null)
+            {
+                components.Dispose();
+            }
             base.Dispose(disposing);
         }
 
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.numInterval = new NumericUpDown();
-            this.cmbUnit = new ComboBox();
-            this.chkAutoStart = new CheckBox();
-            this.btnSave = new Button();
-
+            this.tabControl = new System.Windows.Forms.TabControl();
+            this.tabGeneral = new System.Windows.Forms.TabPage();
+            this.tabApplications = new System.Windows.Forms.TabPage();
+            this.numInterval = new System.Windows.Forms.NumericUpDown();
+            this.cmbUnit = new System.Windows.Forms.ComboBox();
+            this.chkAutoStart = new System.Windows.Forms.CheckBox();
+            this.chkGlobalMonitoring = new System.Windows.Forms.CheckBox();
+            this.lvApplications = new System.Windows.Forms.ListView();
+            this.colName = new System.Windows.Forms.ColumnHeader();
+            this.colService = new System.Windows.Forms.ColumnHeader();
+            this.colProcesses = new System.Windows.Forms.ColumnHeader();
+            this.colExecutable = new System.Windows.Forms.ColumnHeader();
+            this.colMonitoring = new System.Windows.Forms.ColumnHeader();
+            this.btnAddApplication = new System.Windows.Forms.Button();
+            this.btnEditApplication = new System.Windows.Forms.Button();
+            this.btnRemoveApplication = new System.Windows.Forms.Button();
+            this.btnSave = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            var tableGeneral = new System.Windows.Forms.TableLayoutPanel();
+            var intervalPanel = new System.Windows.Forms.FlowLayoutPanel();
+            var appsLayout = new System.Windows.Forms.TableLayoutPanel();
+            var appsButtons = new System.Windows.Forms.FlowLayoutPanel();
+            var actionsPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.tabControl.SuspendLayout();
+            this.tabGeneral.SuspendLayout();
+            this.tabApplications.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numInterval)).BeginInit();
+            tableGeneral.SuspendLayout();
+            intervalPanel.SuspendLayout();
+            appsLayout.SuspendLayout();
+            appsButtons.SuspendLayout();
+            actionsPanel.SuspendLayout();
             this.SuspendLayout();
-
+            // 
+            // tabControl
+            // 
+            this.tabControl.Controls.Add(this.tabGeneral);
+            this.tabControl.Controls.Add(this.tabApplications);
+            this.tabControl.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tabControl.Location = new System.Drawing.Point(0, 0);
+            this.tabControl.Name = "tabControl";
+            this.tabControl.SelectedIndex = 0;
+            this.tabControl.Size = new System.Drawing.Size(800, 450);
+            this.tabControl.TabIndex = 0;
+            // 
+            // tabGeneral
+            // 
+            this.tabGeneral.Controls.Add(tableGeneral);
+            this.tabGeneral.Location = new System.Drawing.Point(4, 24);
+            this.tabGeneral.Name = "tabGeneral";
+            this.tabGeneral.Padding = new System.Windows.Forms.Padding(10);
+            this.tabGeneral.Size = new System.Drawing.Size(792, 422);
+            this.tabGeneral.TabIndex = 0;
+            this.tabGeneral.Text = "General";
+            this.tabGeneral.UseVisualStyleBackColor = true;
+            // 
+            // tabApplications
+            // 
+            this.tabApplications.Controls.Add(appsLayout);
+            this.tabApplications.Location = new System.Drawing.Point(4, 24);
+            this.tabApplications.Name = "tabApplications";
+            this.tabApplications.Padding = new System.Windows.Forms.Padding(10);
+            this.tabApplications.Size = new System.Drawing.Size(792, 422);
+            this.tabApplications.TabIndex = 1;
+            this.tabApplications.Text = "Applications";
+            this.tabApplications.UseVisualStyleBackColor = true;
+            // 
             // numInterval
-            this.numInterval.Location = new System.Drawing.Point(20, 20);
-            this.numInterval.Minimum = 1;
-            this.numInterval.Maximum = 100000;
-            this.numInterval.Value = 5;
-            this.numInterval.Size = new System.Drawing.Size(80, 23);
-
+            // 
+            this.numInterval.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            this.numInterval.Maximum = new decimal(new int[] { 10080, 0, 0, 0 });
+            this.numInterval.Value = new decimal(new int[] { 5, 0, 0, 0 });
+            this.numInterval.Width = 80;
+            // 
             // cmbUnit
-            this.cmbUnit.DropDownStyle = ComboBoxStyle.DropDownList;
+            // 
+            this.cmbUnit.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbUnit.FormattingEnabled = true;
             this.cmbUnit.Items.AddRange(new object[] { "Minutes", "Hours", "Days" });
-            this.cmbUnit.Location = new System.Drawing.Point(110, 20);
-            this.cmbUnit.SelectedIndex = 0;
-            this.cmbUnit.Size = new System.Drawing.Size(120, 23);
-
+            this.cmbUnit.Width = 120;
+            // 
             // chkAutoStart
-            this.chkAutoStart.Text = "Run at Windows startup";
-            this.chkAutoStart.Location = new System.Drawing.Point(20, 60);
-            this.chkAutoStart.Size = new System.Drawing.Size(200, 24);
-
-            // btnSave
+            // 
+            this.chkAutoStart.AutoSize = true;
+            this.chkAutoStart.Text = "Run ServiceWatchdogArr at Windows startup";
+            // 
+            // chkGlobalMonitoring
+            // 
+            this.chkGlobalMonitoring.AutoSize = true;
+            this.chkGlobalMonitoring.Text = "Enable monitoring on launch";
+            // 
+            // lvApplications
+            // 
+            this.lvApplications.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+                this.colName,
+                this.colService,
+                this.colProcesses,
+                this.colExecutable,
+                this.colMonitoring });
+            this.lvApplications.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lvApplications.FullRowSelect = true;
+            this.lvApplications.HideSelection = false;
+            this.lvApplications.MultiSelect = false;
+            this.lvApplications.View = System.Windows.Forms.View.Details;
+            this.lvApplications.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            // 
+            // Columns
+            // 
+            this.colName.Text = "Name";
+            this.colName.Width = 160;
+            this.colService.Text = "Service";
+            this.colService.Width = 140;
+            this.colProcesses.Text = "Processes";
+            this.colProcesses.Width = 180;
+            this.colExecutable.Text = "Executable";
+            this.colExecutable.Width = 220;
+            this.colMonitoring.Text = "Monitoring";
+            this.colMonitoring.Width = 120;
+            // 
+            // Buttons
+            // 
+            this.btnAddApplication.AutoSize = true;
+            this.btnAddApplication.Text = "Add…";
+            this.btnEditApplication.AutoSize = true;
+            this.btnEditApplication.Text = "Edit…";
+            this.btnRemoveApplication.AutoSize = true;
+            this.btnRemoveApplication.Text = "Remove";
+            this.btnSave.AutoSize = true;
             this.btnSave.Text = "Save";
-            this.btnSave.Location = new System.Drawing.Point(20, 100);
-            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
-
+            this.btnCancel.AutoSize = true;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            // 
+            // tableGeneral
+            // 
+            tableGeneral.ColumnCount = 2;
+            tableGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 40F));
+            tableGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 60F));
+            tableGeneral.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableGeneral.RowCount = 4;
+            tableGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            tableGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            tableGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            tableGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            tableGeneral.Padding = new System.Windows.Forms.Padding(10);
+            var lblInterval = new System.Windows.Forms.Label { Text = "Check interval:", AutoSize = true, Padding = new System.Windows.Forms.Padding(0, 6, 0, 0) };
+            var lblGlobal = new System.Windows.Forms.Label { Text = "Monitoring:", AutoSize = true, Padding = new System.Windows.Forms.Padding(0, 6, 0, 0) };
+            tableGeneral.Controls.Add(lblInterval, 0, 0);
+            intervalPanel.FlowDirection = System.Windows.Forms.FlowDirection.LeftToRight;
+            intervalPanel.AutoSize = true;
+            intervalPanel.Controls.Add(this.numInterval);
+            intervalPanel.Controls.Add(this.cmbUnit);
+            tableGeneral.Controls.Add(intervalPanel, 1, 0);
+            tableGeneral.Controls.Add(this.chkAutoStart, 1, 1);
+            tableGeneral.Controls.Add(lblGlobal, 0, 2);
+            tableGeneral.Controls.Add(this.chkGlobalMonitoring, 1, 2);
+            // 
+            // appsLayout
+            // 
+            appsLayout.ColumnCount = 2;
+            appsLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            appsLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 140F));
+            appsLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+            appsLayout.RowCount = 1;
+            appsLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            appsLayout.Controls.Add(this.lvApplications, 0, 0);
+            appsButtons.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            appsButtons.Dock = System.Windows.Forms.DockStyle.Fill;
+            appsButtons.AutoSize = true;
+            appsButtons.Controls.Add(this.btnAddApplication);
+            appsButtons.Controls.Add(this.btnEditApplication);
+            appsButtons.Controls.Add(this.btnRemoveApplication);
+            appsLayout.Controls.Add(appsButtons, 1, 0);
+            // 
+            // actionsPanel
+            // 
+            actionsPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            actionsPanel.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            actionsPanel.Padding = new System.Windows.Forms.Padding(10);
+            actionsPanel.AutoSize = true;
+            actionsPanel.Controls.Add(this.btnSave);
+            actionsPanel.Controls.Add(this.btnCancel);
+            // 
             // SettingsForm
-            this.ClientSize = new System.Drawing.Size(260, 150);
-            this.Controls.Add(this.numInterval);
-            this.Controls.Add(this.cmbUnit);
-            this.Controls.Add(this.chkAutoStart);
-            this.Controls.Add(this.btnSave);
-            this.FormBorderStyle = FormBorderStyle.FixedDialog;
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.StartPosition = FormStartPosition.CenterScreen;
+            // 
+            this.AcceptButton = this.btnSave;
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(800, 490);
+            this.Controls.Add(this.tabControl);
+            this.Controls.Add(actionsPanel);
+            this.MinimumSize = new System.Drawing.Size(620, 420);
+            this.Name = "SettingsForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "ServiceWatchdogArr Settings";
-
+            this.tabControl.ResumeLayout(false);
+            this.tabGeneral.ResumeLayout(false);
+            this.tabApplications.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.numInterval)).EndInit();
+            tableGeneral.ResumeLayout(false);
+            tableGeneral.PerformLayout();
+            intervalPanel.ResumeLayout(false);
+            intervalPanel.PerformLayout();
+            appsLayout.ResumeLayout(false);
+            appsLayout.PerformLayout();
+            appsButtons.ResumeLayout(false);
+            appsButtons.PerformLayout();
+            actionsPanel.ResumeLayout(false);
+            actionsPanel.PerformLayout();
             this.ResumeLayout(false);
+            this.PerformLayout();
         }
     }
 }

--- a/SettingsForm.cs
+++ b/SettingsForm.cs
@@ -1,37 +1,156 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace ServiceWatchdogArr
 {
     public partial class SettingsForm : Form
     {
-        private WatchdogConfig _config;
+        private readonly WatchdogConfig _config;
 
-        public SettingsForm()
+        public event Action<WatchdogConfig> SettingsSaved;
+
+        public SettingsForm(WatchdogConfig config)
         {
             InitializeComponent();
-            _config = WatchdogConfig.Load();
-
-            numInterval.Value = Math.Max(1, _config.Interval.Value);
-            cmbUnit.Items.Clear();
-            cmbUnit.Items.AddRange(new object[] { "Minutes", "Hours", "Days" });
-            cmbUnit.SelectedItem = string.IsNullOrWhiteSpace(_config.Interval.Unit) ? "Minutes" : _config.Interval.Unit;
-
-            chkAutoStart.Checked = _config.AutoStart || AutoStartHelper.IsEnabled();
+            _config = config?.Clone() ?? throw new ArgumentNullException(nameof(config));
+            LoadConfig();
+            HookEvents();
         }
 
-        private void btnSave_Click(object? sender, EventArgs e)
+        private void LoadConfig()
+        {
+            numInterval.Value = Math.Clamp(_config.Interval.Value, 1, 10080);
+            string unitText = _config.Interval.Unit.ToString();
+            int unitIndex = cmbUnit.Items.IndexOf(unitText);
+            cmbUnit.SelectedIndex = unitIndex >= 0 ? unitIndex : 0;
+            chkAutoStart.Checked = _config.AutoStart || AutoStartHelper.IsEnabled();
+            chkGlobalMonitoring.Checked = _config.GlobalMonitoringEnabled;
+            PopulateApplicationList();
+        }
+
+        private void HookEvents()
+        {
+            btnSave.Click += (_, _) => SaveAndClose();
+            btnCancel.Click += (_, _) => Close();
+            btnAddApplication.Click += (_, _) => AddApplication();
+            btnEditApplication.Click += (_, _) => EditSelectedApplication();
+            btnRemoveApplication.Click += (_, _) => RemoveSelectedApplication();
+            lvApplications.DoubleClick += (_, _) => EditSelectedApplication();
+            lvApplications.SelectedIndexChanged += (_, _) => UpdateApplicationButtons();
+            UpdateApplicationButtons();
+        }
+
+        private void PopulateApplicationList()
+        {
+            lvApplications.Items.Clear();
+            foreach (MonitoredApplication application in _config.Applications)
+            {
+                var item = new ListViewItem(application.Name)
+                {
+                    Tag = application
+                };
+                item.SubItems.Add(string.IsNullOrWhiteSpace(application.ServiceName) ? "-" : application.ServiceName);
+                item.SubItems.Add(application.ProcessNames.Count == 0 ? "-" : string.Join(", ", application.ProcessNames));
+                item.SubItems.Add(string.IsNullOrWhiteSpace(application.ExecutablePath) ? "-" : application.ExecutablePath);
+                item.SubItems.Add(application.MonitoringEnabled ? "Enabled" : "Disabled");
+                lvApplications.Items.Add(item);
+            }
+        }
+
+        private void UpdateApplicationButtons()
+        {
+            bool hasSelection = lvApplications.SelectedItems.Count == 1;
+            btnEditApplication.Enabled = hasSelection;
+            btnRemoveApplication.Enabled = hasSelection;
+        }
+
+        private void AddApplication()
+        {
+            using var editor = new ApplicationEditorForm();
+            if (editor.ShowDialog(this) == DialogResult.OK)
+            {
+                MonitoredApplication application = editor.GetApplication();
+                if (_config.Applications.Any(app => string.Equals(app.Name, application.Name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    MessageBox.Show(this, "An application with this name already exists.", "Duplicate Name", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+
+                _config.Applications.Add(application);
+                PopulateApplicationList();
+            }
+        }
+
+        private void EditSelectedApplication()
+        {
+            if (lvApplications.SelectedItems.Count != 1)
+            {
+                return;
+            }
+
+            var item = lvApplications.SelectedItems[0];
+            var application = (MonitoredApplication)item.Tag;
+
+            using var editor = new ApplicationEditorForm(application);
+            if (editor.ShowDialog(this) == DialogResult.OK)
+            {
+                MonitoredApplication updated = editor.GetApplication();
+                if (_config.Applications.Any(app => !ReferenceEquals(app, application) && string.Equals(app.Name, updated.Name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    MessageBox.Show(this, "An application with this name already exists.", "Duplicate Name", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+
+                application.Name = updated.Name;
+                application.ServiceName = updated.ServiceName;
+                application.ExecutablePath = updated.ExecutablePath;
+                application.ProcessNames = new List<string>(updated.ProcessNames);
+                application.MonitoringEnabled = updated.MonitoringEnabled;
+                PopulateApplicationList();
+            }
+        }
+
+        private void RemoveSelectedApplication()
+        {
+            if (lvApplications.SelectedItems.Count != 1)
+            {
+                return;
+            }
+
+            var item = lvApplications.SelectedItems[0];
+            var application = (MonitoredApplication)item.Tag;
+            var confirm = MessageBox.Show(this, $"Remove {application.Name} from monitoring?", "Confirm", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+            if (confirm == DialogResult.Yes)
+            {
+                _config.Applications.Remove(application);
+                PopulateApplicationList();
+            }
+        }
+
+        private void SaveAndClose()
         {
             _config.Interval.Value = (int)numInterval.Value;
-            _config.Interval.Unit = cmbUnit.SelectedItem?.ToString() ?? "Minutes";
+            if (!Enum.TryParse(cmbUnit.SelectedItem?.ToString(), out IntervalUnit unit))
+            {
+                unit = IntervalUnit.Minutes;
+            }
+            _config.Interval.Unit = unit;
             _config.AutoStart = chkAutoStart.Checked;
+            _config.GlobalMonitoringEnabled = chkGlobalMonitoring.Checked;
 
-            if (chkAutoStart.Checked) AutoStartHelper.Enable(Application.ExecutablePath);
-            else AutoStartHelper.Disable();
+            if (_config.AutoStart)
+            {
+                AutoStartHelper.Enable(Application.ExecutablePath);
+            }
+            else
+            {
+                AutoStartHelper.Disable();
+            }
 
-            _config.Save();
-
-            DialogResult = DialogResult.OK;
+            _config.Normalize();
+            SettingsSaved?.Invoke(_config.Clone());
             Close();
         }
     }

--- a/SingleInstanceManager.cs
+++ b/SingleInstanceManager.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Threading;
+
+namespace ServiceWatchdogArr
+{
+    internal sealed class SingleInstanceManager : IDisposable
+    {
+        private const string MutexName = "Local/ServiceWatchdogArr.SingleInstance";
+        private const string EventName = "Local/ServiceWatchdogArr.Show";
+
+        private readonly Mutex _mutex;
+        private readonly EventWaitHandle _showHandle;
+        private readonly RegisteredWaitHandle _registeredWait;
+        private readonly Action _showCallback;
+        private bool _disposed;
+
+        private SingleInstanceManager(Mutex mutex, EventWaitHandle showHandle, RegisteredWaitHandle registeredWait, Action showCallback)
+        {
+            _mutex = mutex;
+            _showHandle = showHandle;
+            _registeredWait = registeredWait;
+            _showCallback = showCallback;
+        }
+
+        public static bool TryAcquire(Action showCallback, out SingleInstanceManager manager)
+        {
+            manager = null;
+            if (showCallback == null)
+            {
+                throw new ArgumentNullException(nameof(showCallback));
+            }
+
+            bool createdNew;
+            Mutex mutex = new Mutex(initiallyOwned: true, name: MutexName, createdNew: out createdNew);
+            if (!createdNew)
+            {
+                mutex.Dispose();
+                return false;
+            }
+
+            EventWaitHandle showHandle = new EventWaitHandle(false, EventResetMode.AutoReset, EventName);
+            RegisteredWaitHandle registeredWait = ThreadPool.RegisterWaitForSingleObject(
+                showHandle,
+                (_, _) => showCallback(),
+                null,
+                Timeout.Infinite,
+                executeOnlyOnce: false);
+
+            manager = new SingleInstanceManager(mutex, showHandle, registeredWait, showCallback);
+            return true;
+        }
+
+        public static void SignalExistingInstance()
+        {
+            try
+            {
+                using EventWaitHandle showHandle = EventWaitHandle.OpenExisting(EventName);
+                showHandle.Set();
+            }
+            catch
+            {
+                // Nothing to do if signaling fails.
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _registeredWait?.Unregister(null);
+            _showHandle?.Dispose();
+            _mutex.ReleaseMutex();
+            _mutex.Dispose();
+        }
+    }
+}

--- a/WatchdogConfig.cs
+++ b/WatchdogConfig.cs
@@ -1,127 +1,370 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace ServiceWatchdogArr
 {
-    public class IntervalConfig
+    internal enum IntervalUnit
+    {
+        Minutes,
+        Hours,
+        Days
+    }
+
+    internal sealed class IntervalConfig
     {
         public int Value { get; set; } = 5;
-        public string Unit { get; set; } = "Minutes"; // Minutes, Hours, Days
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public IntervalUnit Unit { get; set; } = IntervalUnit.Minutes;
+
+        public TimeSpan ToTimeSpan()
+        {
+            int clampedValue = Math.Clamp(Value <= 0 ? 1 : Value, 1, 7 * 24 * 60);
+            Value = clampedValue;
+
+            return Unit switch
+            {
+                IntervalUnit.Hours => TimeSpan.FromMinutes(Math.Clamp(clampedValue * 60, 1, 7 * 24 * 60)),
+                IntervalUnit.Days => TimeSpan.FromMinutes(Math.Clamp(clampedValue * 24 * 60, 1, 7 * 24 * 60)),
+                _ => TimeSpan.FromMinutes(clampedValue)
+            };
+        }
+
+        public IntervalConfig Clone()
+        {
+            return new IntervalConfig
+            {
+                Value = Value,
+                Unit = Unit
+            };
+        }
     }
 
-    public class WatchedApplication
+    internal sealed class MonitoredApplication
     {
         public string Name { get; set; } = string.Empty;
-        public string? ProcessName { get; set; }
-        public string? ExecutablePath { get; set; }
-        public string? ServiceName { get; set; }
 
-        public static List<WatchedApplication> CreateDefaults() => new()
+        public string ServiceName { get; set; } = string.Empty;
+
+        public List<string> ProcessNames { get; set; } = new List<string>();
+
+        public string ExecutablePath { get; set; } = string.Empty;
+
+        public bool MonitoringEnabled { get; set; } = true;
+
+        public MonitoredApplication Clone()
         {
-            new WatchedApplication
+            return new MonitoredApplication
             {
-                Name = "Plex Media Server",
-                ProcessName = "Plex Media Server",
-                ExecutablePath = @"C:\\Program Files\\Plex\\Plex Media Server\\Plex Media Server.exe",
-                ServiceName = "PlexUpdateService"
-            },
-            new WatchedApplication
-            {
-                Name = "Radarr",
-                ProcessName = "Radarr",
-                ExecutablePath = @"C:\\ProgramData\\Radarr\\Radarr.exe",
-                ServiceName = "Radarr"
-            },
-            new WatchedApplication
-            {
-                Name = "Sonarr",
-                ProcessName = "Sonarr",
-                ExecutablePath = @"C:\\ProgramData\\Sonarr\\bin\\Sonarr.exe",
-                ServiceName = "Sonarr"
-            },
-            new WatchedApplication
-            {
-                Name = "Docker Desktop",
-                ProcessName = "Docker Desktop",
-                ExecutablePath = @"C:\\Program Files\\Docker\\Docker\\frontend\\Docker Desktop.exe",
-                ServiceName = "com.docker.service"
-            },
-            new WatchedApplication
-            {
-                Name = "Corsair iCUE",
-                ProcessName = "iCUE",
-                ExecutablePath = @"C:\\Program Files\\Corsair\\Corsair iCUE5 Software\\iCUE.exe"
-            }
-        };
+                Name = Name,
+                ServiceName = ServiceName,
+                ExecutablePath = ExecutablePath,
+                MonitoringEnabled = MonitoringEnabled,
+                ProcessNames = new List<string>(ProcessNames)
+            };
+        }
+
+        public void Normalize()
+        {
+            Name = Name?.Trim() ?? string.Empty;
+            ServiceName = ServiceName?.Trim() ?? string.Empty;
+            ExecutablePath = ExecutablePath?.Trim() ?? string.Empty;
+            ProcessNames = ProcessNames
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Select(static name => ProcessNameHelper.Normalize(name))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
     }
 
-    public class WatchdogConfig
+    internal sealed class WatchdogConfig
     {
         public IntervalConfig Interval { get; set; } = new IntervalConfig();
-        public bool AutoStart { get; set; } = false;
-        public List<WatchedApplication> Applications { get; set; } = WatchedApplication.CreateDefaults();
 
-        public int IntervalMinutes => Interval.Unit switch
-        {
-            "Hours" => Math.Max(1, Interval.Value) * 60,
-            "Days"  => Math.Max(1, Interval.Value) * 24 * 60,
-            _       => Math.Max(1, Interval.Value)
-        };
+        public bool AutoStart { get; set; }
 
-        public static WatchdogConfig Load()
+        public bool GlobalMonitoringEnabled { get; set; } = true;
+
+        public List<MonitoredApplication> Applications { get; set; } = new List<MonitoredApplication>();
+
+        [JsonIgnore]
+        public TimeSpan MonitoringInterval => Interval.ToTimeSpan();
+
+        public WatchdogConfig Clone()
         {
-            try
+            return new WatchdogConfig
             {
-                string path = RootConfig.GetConfigFilePath();
-                if (File.Exists(path))
-                {
-                    string json = File.ReadAllText(path);
-                    var root = JsonSerializer.Deserialize<RootConfig>(json);
-                    if (root?.WatchdogConfig != null)
-                    {
-                        root.WatchdogConfig.EnsureDefaults();
-                        return root.WatchdogConfig;
-                    }
-                }
-            }
-            catch { }
-            var fallback = new WatchdogConfig();
-            fallback.EnsureDefaults();
-            return fallback;
+                Interval = Interval.Clone(),
+                AutoStart = AutoStart,
+                GlobalMonitoringEnabled = GlobalMonitoringEnabled,
+                Applications = Applications.Select(app => app.Clone()).ToList()
+            };
         }
 
-        public void Save()
+        public void Normalize()
         {
-            try
+            Interval.ToTimeSpan();
+            foreach (MonitoredApplication application in Applications)
             {
-                EnsureDefaults();
-                var root = new RootConfig { WatchdogConfig = this };
-                Directory.CreateDirectory(Path.GetDirectoryName(RootConfig.GetConfigFilePath())!);
-                File.WriteAllText(RootConfig.GetConfigFilePath(),
-                    JsonSerializer.Serialize(root, new JsonSerializerOptions { WriteIndented = true }));
+                application.Normalize();
             }
-            catch { }
-        }
-
-        private void EnsureDefaults()
-        {
-            if (Applications == null || Applications.Count == 0)
-                Applications = WatchedApplication.CreateDefaults();
         }
     }
 
-    public class RootConfig
+    internal sealed class ConfigManager
     {
-        public WatchdogConfig WatchdogConfig { get; set; } = new WatchdogConfig();
+        private readonly object _syncRoot = new object();
+        private readonly JsonSerializerOptions _serializerOptions;
+        private WatchdogConfig _config;
 
-        private static readonly string ConfigDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "ServiceWatchdogArr");
+        public ConfigManager()
+        {
+            _serializerOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = null,
+                ReadCommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true
+            };
+            _serializerOptions.Converters.Add(new JsonStringEnumConverter());
 
-        private static readonly string ConfigFile = Path.Combine(ConfigDir, "appsettings.json");
+            _config = LoadFromDisk();
+        }
 
-        public static string GetConfigFilePath() => ConfigFile;
+        public WatchdogConfig GetSnapshot()
+        {
+            lock (_syncRoot)
+            {
+                return _config.Clone();
+            }
+        }
+
+        public WatchdogConfig Update(Func<WatchdogConfig, WatchdogConfig> updater)
+        {
+            if (updater == null)
+            {
+                throw new ArgumentNullException(nameof(updater));
+            }
+
+            lock (_syncRoot)
+            {
+                WatchdogConfig snapshot = _config.Clone();
+                WatchdogConfig updated = updater(snapshot) ?? snapshot;
+                updated.Normalize();
+                _config = updated.Clone();
+                SaveToDisk(updated);
+                return _config.Clone();
+            }
+        }
+
+        public WatchdogConfig Update(Action<WatchdogConfig> updater)
+        {
+            return Update(config =>
+            {
+                updater(config);
+                return config;
+            });
+        }
+
+        private WatchdogConfig LoadFromDisk()
+        {
+            try
+            {
+                if (!File.Exists(Paths.ConfigFilePath))
+                {
+                    return CreateDefaultConfig();
+                }
+
+                string json = File.ReadAllText(Paths.ConfigFilePath);
+                JsonNode rootNode = JsonNode.Parse(json) ?? new JsonObject();
+
+                JsonObject configNode = EnsureConfigNode(rootNode);
+                var config = configNode.Deserialize<WatchdogConfig>(_serializerOptions) ?? CreateDefaultConfig();
+                EnsureApplicationDefaults(config);
+                config.Normalize();
+                return config;
+            }
+            catch (Exception ex)
+            {
+                Logger.Write(ex, "Failed to load configuration; reverting to defaults");
+                return CreateDefaultConfig();
+            }
+        }
+
+        private void SaveToDisk(WatchdogConfig config)
+        {
+            try
+            {
+                Directory.CreateDirectory(Paths.AppDataDirectory);
+                var root = new JsonObject
+                {
+                    ["WatchdogConfig"] = JsonNode.Parse(JsonSerializer.Serialize(config, _serializerOptions))
+                };
+                File.WriteAllText(Paths.ConfigFilePath, root.ToJsonString(_serializerOptions));
+            }
+            catch (Exception ex)
+            {
+                Logger.Write(ex, "Failed to persist configuration");
+            }
+        }
+
+        private static WatchdogConfig CreateDefaultConfig()
+        {
+            var config = new WatchdogConfig
+            {
+                Interval = new IntervalConfig { Value = 5, Unit = IntervalUnit.Minutes },
+                AutoStart = false,
+                GlobalMonitoringEnabled = true,
+                Applications = new List<MonitoredApplication>
+                {
+                    new MonitoredApplication
+                    {
+                        Name = "Docker Desktop",
+                        ServiceName = "com.docker.service",
+                        ExecutablePath = @"C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe",
+                        MonitoringEnabled = true,
+                        ProcessNames = new List<string> { "Docker Desktop", "Docker Desktop Backend" }
+                    }
+                }
+            };
+            config.Normalize();
+            return config;
+        }
+
+        private static void EnsureApplicationDefaults(WatchdogConfig config)
+        {
+            foreach (MonitoredApplication application in config.Applications)
+            {
+                if (application.ProcessNames == null)
+                {
+                    application.ProcessNames = new List<string>();
+                }
+
+                if (application.ProcessNames.Count == 0 && !string.IsNullOrWhiteSpace(application.ServiceName))
+                {
+                    application.ProcessNames.Add(application.ServiceName);
+                }
+
+                application.MonitoringEnabled = application.MonitoringEnabled;
+            }
+        }
+
+        private static JsonObject EnsureConfigNode(JsonNode rootNode)
+        {
+            JsonObject rootObject;
+            if (rootNode is JsonObject jsonObject)
+            {
+                rootObject = jsonObject;
+            }
+            else
+            {
+                rootObject = new JsonObject();
+            }
+
+            if (!rootObject.TryGetPropertyValue("WatchdogConfig", out JsonNode configNode) || configNode is not JsonObject configObject)
+            {
+                configObject = new JsonObject();
+                rootObject["WatchdogConfig"] = configObject;
+            }
+
+            EnsureIntervalDefaults(configObject);
+            EnsureGlobalMonitoring(configObject);
+            EnsureApplicationsArray(configObject);
+            return configObject;
+        }
+
+        private static void EnsureIntervalDefaults(JsonObject configObject)
+        {
+            if (!configObject.TryGetPropertyValue("Interval", out JsonNode intervalNode) || intervalNode is not JsonObject intervalObject)
+            {
+                intervalObject = new JsonObject();
+                configObject["Interval"] = intervalObject;
+            }
+
+            if (!intervalObject.TryGetPropertyValue("Value", out JsonNode valueNode) || valueNode == null)
+            {
+                intervalObject["Value"] = 5;
+            }
+
+            if (!intervalObject.TryGetPropertyValue("Unit", out JsonNode unitNode) || unitNode == null)
+            {
+                intervalObject["Unit"] = IntervalUnit.Minutes.ToString();
+            }
+        }
+
+        private static void EnsureGlobalMonitoring(JsonObject configObject)
+        {
+            if (!configObject.TryGetPropertyValue("GlobalMonitoringEnabled", out JsonNode globalNode) || globalNode == null)
+            {
+                configObject["GlobalMonitoringEnabled"] = true;
+            }
+        }
+
+        private static void EnsureApplicationsArray(JsonObject configObject)
+        {
+            if (!configObject.TryGetPropertyValue("Applications", out JsonNode appsNode) || appsNode is not JsonArray appsArray)
+            {
+                appsArray = new JsonArray();
+                configObject["Applications"] = appsArray;
+            }
+
+            foreach (JsonNode? node in appsArray)
+            {
+                if (node is not JsonObject appObject)
+                {
+                    continue;
+                }
+
+                if (!appObject.TryGetPropertyValue("MonitoringEnabled", out JsonNode enabledNode) || enabledNode == null)
+                {
+                    appObject["MonitoringEnabled"] = true;
+                }
+
+                if (appObject.TryGetPropertyValue("ProcessNames", out JsonNode processNode))
+                {
+                    if (processNode is JsonValue value && value.TryGetValue<string>(out string singleProcess))
+                    {
+                        appObject["ProcessNames"] = new JsonArray(singleProcess);
+                    }
+                    else if (processNode == null)
+                    {
+                        appObject["ProcessNames"] = new JsonArray();
+                    }
+                }
+                else if (appObject.TryGetPropertyValue("ProcessName", out JsonNode legacyProcessNode) && legacyProcessNode is JsonValue legacyValue && legacyValue.TryGetValue<string>(out string legacyProcess))
+                {
+                    appObject["ProcessNames"] = new JsonArray(legacyProcess);
+                }
+
+                if (!appObject.TryGetPropertyValue("ProcessNames", out JsonNode ensuredNode) || ensuredNode is not JsonArray)
+                {
+                    appObject["ProcessNames"] = new JsonArray();
+                }
+            }
+        }
+    }
+
+    internal static class ProcessNameHelper
+    {
+        public static string Normalize(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return string.Empty;
+            }
+
+            string trimmed = name.Trim();
+            if (trimmed.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            {
+                trimmed = trimmed[..^4];
+            }
+
+            return trimmed;
+        }
     }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -5,35 +5,17 @@
       "Unit": "Minutes"
     },
     "AutoStart": false,
+    "GlobalMonitoringEnabled": true,
     "Applications": [
       {
-        "Name": "Plex Media Server",
-        "ProcessName": "Plex Media Server",
-        "ExecutablePath": "C:\\\\Program Files\\\\Plex\\\\Plex Media Server\\\\Plex Media Server.exe",
-        "ServiceName": "PlexUpdateService"
-      },
-      {
-        "Name": "Radarr",
-        "ProcessName": "Radarr",
-        "ExecutablePath": "C:\\\\ProgramData\\\\Radarr\\\\Radarr.exe",
-        "ServiceName": "Radarr"
-      },
-      {
-        "Name": "Sonarr",
-        "ProcessName": "Sonarr",
-        "ExecutablePath": "C:\\\\ProgramData\\\\Sonarr\\\\bin\\\\Sonarr.exe",
-        "ServiceName": "Sonarr"
-      },
-      {
         "Name": "Docker Desktop",
-        "ProcessName": "Docker Desktop",
-        "ExecutablePath": "C:\\\\Program Files\\\\Docker\\\\Docker\\\\frontend\\\\Docker Desktop.exe",
-        "ServiceName": "com.docker.service"
-      },
-      {
-        "Name": "Corsair iCUE",
-        "ProcessName": "iCUE",
-        "ExecutablePath": "C:\\\\Program Files\\\\Corsair\\\\Corsair iCUE5 Software\\\\iCUE.exe"
+        "ServiceName": "com.docker.service",
+        "ProcessNames": [
+          "Docker Desktop",
+          "Docker Desktop Backend"
+        ],
+        "ExecutablePath": "C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe",
+        "MonitoringEnabled": true
       }
     ]
   }

--- a/packaging/winget/manifest.yaml
+++ b/packaging/winget/manifest.yaml
@@ -1,0 +1,12 @@
+# WinGet manifest template for ServiceWatchdogArr portable package
+Id: ServiceWatchdogArr.ServiceWatchdogArr
+Publisher: ServiceWatchdogArr
+Name: ServiceWatchdogArr
+Version: 0.1.0
+License: MIT
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://example.com/ServiceWatchdogArr-0.1.0.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+ShortDescription: Tray application that monitors user-selected services and processes and restarts them when required.

--- a/program.cs
+++ b/program.cs
@@ -3,14 +3,32 @@ using System.Windows.Forms;
 
 namespace ServiceWatchdogArr
 {
-    static class Program
+    internal static class Program
     {
         [STAThread]
-        static void Main()
+        private static void Main(string[] args)
         {
+            ApplicationArguments.Initialize(args);
+            Logger.EnsureLogExists();
+            CrashReporter.Initialize();
+            CrashReporter.CheckForRecentCrash();
+
+            if (!SingleInstanceManager.TryAcquire(WatchdogApplicationContext.RequestBringToForeground, out SingleInstanceManager instanceManager))
+            {
+                SingleInstanceManager.SignalExistingInstance();
+                return;
+            }
+
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new WatchdogApplicationContext());
+            Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
+            Logger.Write(ApplicationArguments.SafeMode ? "Starting in safe mode" : "Starting ServiceWatchdogArr");
+
+            using (instanceManager)
+            using (var context = new WatchdogApplicationContext())
+            {
+                Application.Run(context);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- rebuild the tray context to drive single-instance startup, safe-mode aware monitoring, and per-application restart controls
- add background monitoring, configuration persistence, logging, and crash-handling infrastructure for services and processes
- refresh the settings UI with discovery dialogs and ship updated documentation plus a WinGet manifest template

## Testing
- dotnet build *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d38e3e43e08321b5d3b1f0456e111d