### PR TITLE
Fix compilation errors and align service restart results

### DIFF
--- a/MonitoringEngine.cs
+++ b/MonitoringEngine.cs
@@ -12,7 +12,7 @@ namespace ServiceWatchdogArr
         private readonly ProcessManager _processManager = new ProcessManager();
         private readonly object _syncRoot = new object();
         private readonly SemaphoreSlim _cycleLock = new SemaphoreSlim(1, 1);
-        private Timer _timer;
+        private System.Threading.Timer _timer;
         private WatchdogConfig _config;
         private List<ApplicationStatusSnapshot> _latest = new List<ApplicationStatusSnapshot>();
         private bool _disposed;
@@ -20,7 +20,7 @@ namespace ServiceWatchdogArr
         public MonitoringEngine(WatchdogConfig config)
         {
             _config = config.Clone();
-            _timer = new Timer(OnTimerTick, null, TimeSpan.Zero, _config.MonitoringInterval);
+            _timer = new System.Threading.Timer(OnTimerTick, null, TimeSpan.Zero, _config.MonitoringInterval);
         }
 
         public event EventHandler<MonitoringCycleEventArgs> MonitoringCycleCompleted;

--- a/ServiceManager.cs
+++ b/ServiceManager.cs
@@ -68,7 +68,7 @@ namespace ServiceWatchdogArr
             }
             catch (InvalidOperationException ex) when (IsAccessDenied(ex))
             {
-                return ServiceRestartResult.RequiresElevation(ex.Message);
+                return ServiceRestartResult.ElevationRequired(ex.Message);
             }
             catch (Exception ex)
             {
@@ -117,7 +117,7 @@ namespace ServiceWatchdogArr
             Succeeded = succeeded;
             RequiresElevation = requiresElevation;
             Message = message;
-            Skipped = skipped;
+            IsSkipped = skipped;
         }
 
         public bool Succeeded { get; }
@@ -126,11 +126,11 @@ namespace ServiceWatchdogArr
 
         public string Message { get; }
 
-        public bool Skipped { get; }
+        public bool IsSkipped { get; }
 
         public static ServiceRestartResult Success => new ServiceRestartResult(true, false, string.Empty, false);
 
-        public static ServiceRestartResult RequiresElevation(string message) => new ServiceRestartResult(false, true, message, false);
+        public static ServiceRestartResult ElevationRequired(string message) => new ServiceRestartResult(false, true, message, false);
 
         public static ServiceRestartResult Failure(string message) => new ServiceRestartResult(false, false, message, false);
 

--- a/SettingsForm.cs
+++ b/SettingsForm.cs
@@ -5,11 +5,11 @@ using System.Windows.Forms;
 
 namespace ServiceWatchdogArr
 {
-    public partial class SettingsForm : Form
+    internal partial class SettingsForm : Form
     {
         private readonly WatchdogConfig _config;
 
-        public event Action<WatchdogConfig> SettingsSaved;
+        internal event Action<WatchdogConfig> SettingsSaved;
 
         public SettingsForm(WatchdogConfig config)
         {

--- a/WatchdogApplicationContext.cs
+++ b/WatchdogApplicationContext.cs
@@ -504,7 +504,7 @@ namespace ServiceWatchdogArr
                     Logger.Write($"Service restart failed for {application.Name}: administrator rights required.");
                     _serviceRequiresElevation[application.ServiceName] = true;
                 }
-                else if (!serviceResult.Skipped)
+                else if (!serviceResult.IsSkipped)
                 {
                     Logger.Write($"Service restart failed for {application.Name}: {serviceResult.Message}");
                 }


### PR DESCRIPTION
## Summary
- ensure MonitoringEngine uses System.Threading.Timer to avoid ambiguous references
- scope SettingsForm and its event to internal to satisfy accessibility rules
- rename ServiceRestartResult members to eliminate naming collisions and update callers

## Testing
- `dotnet build -c Release` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d39a0eb6e48321b3372f349bec9300